### PR TITLE
Include font-face definitions

### DIFF
--- a/core/pattern-library/elements.scss
+++ b/core/pattern-library/elements.scss
@@ -1,4 +1,5 @@
 @import 'headers';
+@import 'fonts';
 @import 'elements/document';
 @import 'elements/typography';
 @import 'elements/layout';

--- a/core/pattern-library/elements/document.scss
+++ b/core/pattern-library/elements/document.scss
@@ -4,6 +4,10 @@ html {
     font-size: 62.5%;
 }
 
+.kss-style {
+    font-family: 'Neue Helvetica W01', Georgia, sans-serif;
+}
+
 body {
     @include set-font(body-regular);
 

--- a/core/pattern-library/fonts.scss
+++ b/core/pattern-library/fonts.scss
@@ -1,0 +1,65 @@
+@import url('https://fast.fonts.net/t/1.css?apiType=css&projectid=437b6557-ce99-4f35-97ff-64a93247731f');
+@font-face{
+    font-family: 'Neue Helvetica W01';
+    src: local('Helvetica Neue'),
+        url('/cms/assets/fonts/3a46542f-f429-4821-9a88-62e3be54a640.woff2') format('woff2'),
+        url('/cms/assets/fonts/50ac1699-f3d2-47b6-878f-67a368a17c41.woff') format('woff');
+    font-weight: 300;
+    font-style: normal;
+}
+@font-face{
+    font-family: 'Neue Helvetica W01';
+    src: local('Helvetica Neue'),
+        url('/cms/assets/fonts/261b4efb-3d70-4965-977d-38af9422700d.woff2') format('woff2'),
+        url('/cms/assets/fonts/2e00514e-1764-4250-a0c5-aca3e5a8d133.woff') format('woff');
+    font-weight: 300;
+    font-style: italic;
+}
+@font-face{
+    font-family: 'Neue Helvetica W01';
+    src: local('Helvetica Neue'),
+        url('/cms/assets/fonts/3dac71eb-afa7-4c80-97f0-599202772905.woff2') format('woff2'),
+        url('/cms/assets/fonts/34e0e4c0-c294-49bb-9a8e-1b2cafd54e32.woff') format('woff');
+    font-weight: 400;
+    font-style: normal;
+}
+@font-face{
+    font-family: 'Neue Helvetica W01';
+    src: local('Helvetica Neue'),
+        url('/cms/assets/fonts/21c44514-f4d6-4cff-a5de-e4cac5e61aff.woff2') format('woff2'),
+        url('/cms/assets/fonts/e7c4b231-76ad-47c7-a54b-5d84dcd78d0f.woff') format('woff');
+    font-weight: 400;
+    font-style: italic;
+}
+@font-face{
+    font-family: 'Neue Helvetica W01';
+    src: local('Helvetica Neue'),
+        url('/cms/assets/fonts/5b1fbd62-45dc-4433-a7df-a2b24a146411.woff2') format('woff2'),
+        url('/cms/assets/fonts/050b1948-f226-4d20-a65a-15d8ed031222.woff') format('woff');
+    font-weight: 500;
+    font-style: normal;
+}
+@font-face{
+    font-family: 'Neue Helvetica W01';
+    src: local('Helvetica Neue'),
+        url('/cms/assets/fonts/657c2fa4-585b-4761-9e2e-65ab13159323.woff2') format('woff2'),
+        url('/cms/assets/fonts/400869f0-f0d5-49a0-8a11-f4fb4279d125.woff') format('woff');
+    font-weight: 500;
+    font-style: italic;
+}
+@font-face{
+    font-family: 'Neue Helvetica W01';
+    src: local('Helvetica Neue'),
+        url('/cms/assets/fonts/531c5a28-5575-4f58-96d4-a80f7b702d7b.woff2') format('woff2'),
+        url('/cms/assets/fonts/439c5962-f9fe-4eaf-a1f6-f41d42edba75.woff') format('woff');
+    font-weight: 700;
+    font-style: normal;
+}
+@font-face{
+    font-family: 'Neue Helvetica W01';
+    src: local('Helvetica Neue'),
+        url('/cms/assets/fonts/ade4dbae-c607-4c84-a375-f0c4de0cc357.woff2') format('woff2'),
+        url('/cms/assets/fonts/5b864741-6f14-4ed9-a297-27a4d73edf51.woff') format('woff');
+    font-weight: 700;
+    font-style: italic;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pattern-library",
-  "version": "1.1.7",
+  "version": "1.1.9",
   "description": "SASS files implementing OpenStax pattern library conventions",
   "main": "index.js",
   "style": "core/pattern-library.scss",


### PR DESCRIPTION
Font files are still stored at openstax.org/cms/assets as they
must be pulled from an active web server. Any product in the openstax.org domain
will be able to use them.
Allowing `local('Helvetica Neue')` should save on download times.