### PR TITLE
Bug fixes for Accounts flow

### DIFF
--- a/core/pattern-library/elements/markup/form-elements-input-with-tooltip.html
+++ b/core/pattern-library/elements/markup/form-elements-input-with-tooltip.html
@@ -1,5 +1,6 @@
 <form>
-    <div class="input-with-tooltip">
+    <div class="input-with-tooltip control-group">
+        <label class-="field-label">Some label</label>
         <input placeholder="the input field">
         <div class="tooltip">
             <h3>For some reason, a header</h3>
@@ -7,5 +8,11 @@
             This is the content of the tooltip. I don't care how long it is.
             </div>
         </div>
+    </div>
+    <div class="relative-positioned-text" style="position: relative">
+        Some text after the field<br>
+        It could be long<br>
+        Maybe several lines<br>
+        The tooltip should be over it.
     </div>
 </form>

--- a/core/pattern-library/elements/markup/layout-control-group.html
+++ b/core/pattern-library/elements/markup/layout-control-group.html
@@ -3,7 +3,7 @@
         <div class="control-group basis-12">
             <label class="field-label">Field Label</label>
             <input placeholder="Placeholder text" pattern="g" required>
-            <div class="invalid-message">Enter a g</div>
+            <div class="invalid-message">Enter a g<br>a second line<br>three<br>four<br>five</div>
         </div>
         <div class="control-group basis-6">
             <label class="field-label">Field Label</label>

--- a/core/pattern-library/molecules.scss
+++ b/core/pattern-library/molecules.scss
@@ -185,14 +185,15 @@ $form-border-width: 0.1rem;
         display: unset;
         padding: 1rem 2rem;
         position: absolute;
+        z-index: 1;
 
-        @include width-up-to($phone-max) {
+        @include width-up-to($tablet-max) {
             left: 0;
             top: 100%;
             transform: translateY(#{$tooltip-size + 0.5rem});
         }
 
-        @include wider-than($phone-max) {
+        @include wider-than($tablet-max) {
             left: 0;
             top: 50%;
             transform: translate(calc(-100% - #{$tooltip-size + 0.5rem}), -50%);
@@ -209,13 +210,13 @@ $form-border-width: 0.1rem;
             transform-origin: center;
             width: $tooltip-size;
 
-            @include width-up-to($phone-max) {
+            @include width-up-to($tablet-max) {
                 left: calc(50%);
                 top: #{-$tooltip-size * 1.07};
                 transform: rotate(-135deg) translateY(-63%);
             }
 
-            @include wider-than($phone-max) {
+            @include wider-than($tablet-max) {
                 right: #{-$tooltip-size * 1.07};
                 top: 50%;
                 transform: rotate(-45deg) translateY(-63%);
@@ -269,22 +270,21 @@ $form-border-width: 0.1rem;
 
 %control-group {
     display: block;
-    height: $form-element-height;
+    min-height: $form-element-height;
     margin: 0;
     position: relative;
     width: 100%;
 
     %field-label,
     %invalid-message {
-        position: absolute;
-        top: 0;
-        transform: translateY(-104%);
         width: 100%;
     }
 
     %invalid-message {
         bottom: 0;
-        transform: translateY(100%);
+        margin-bottom: -2rem; // should be line height of text
+        position: relative;
+        transform: none;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pattern-library",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "_version_comment": "When new version, must also update `pattern-library.gemspec`.",
   "description": "SASS files implementing OpenStax pattern library conventions",
   "main": "index.js",

--- a/pattern-library.gemspec
+++ b/pattern-library.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "pattern-library"
-  spec.version       = "1.1.12"
+  spec.version       = "1.1.13"
   spec.authors       = ["Roy Johnson"]
   spec.email         = ["roy.e.johnson@rice.edu"]
 


### PR DESCRIPTION
1. Tooltip should be in front of other content
2. Error message area should expand if message spans multiple lines
3. Tooltips should be below input on tablet as well as phone (and to the left in desktop only)